### PR TITLE
enhancing build anywhere to not force holograms to position of a collided object

### DIFF
--- a/iat/addons/build_anywhere/scripts/4_world/classes/modded_hologram.c
+++ b/iat/addons/build_anywhere/scripts/4_world/classes/modded_hologram.c
@@ -7,4 +7,74 @@ modded class Hologram
 		// turn off collision
 		SetIsColliding(false);
 	}
+
+	override protected vector GetProjectionEntityPosition(PlayerBase player)
+	{
+		float minProjectionDistance;
+		float maxProjectionDistance;
+		m_ContactDir = vector.Zero;
+		vector minMax[2];
+		float projectionRadius = GetProjectionRadius();
+		float cameraToPlayerDistance = vector.Distance(GetGame().GetCurrentCameraPosition(), player.GetPosition());
+
+		if (projectionRadius < SMALL_PROJECTION_RADIUS) // objects with radius smaller than 1m
+		{
+			minProjectionDistance = SMALL_PROJECTION_RADIUS;
+			maxProjectionDistance = SMALL_PROJECTION_RADIUS * 2;
+		}
+		else
+		{
+			minProjectionDistance = projectionRadius;
+			maxProjectionDistance = projectionRadius * 2;
+			maxProjectionDistance = Math.Clamp(maxProjectionDistance, SMALL_PROJECTION_RADIUS, LARGE_PROJECTION_DISTANCE_LIMIT);
+		}
+
+		vector from = GetGame().GetCurrentCameraPosition();
+		vector to = from + (GetGame().GetCurrentCameraDirection() * (maxProjectionDistance + cameraToPlayerDistance));
+		vector contactPosition;
+		set<Object> hitObjects = new set<Object>();
+
+		DayZPhysics.RaycastRV(from, to, contactPosition, m_ContactDir, m_ContactComponent, hitObjects, player, m_Projection, false, false, ObjIntersectFire);
+
+		// bool contactHitProcessed = false;
+		//! will not push hologram up when there is direct hit of an item
+		// if (!CfgGameplayHandler.GetDisableIsCollidingBBoxCheck())
+		// {
+		// 	if (hitObjects.Count() > 0)
+		// 	{
+		// 		if (hitObjects[0].IsInherited(Watchtower))
+		// 		{
+		// 			contactHitProcessed = true;
+		// 			contactPosition = CorrectForWatchtower(m_ContactComponent, contactPosition, player, hitObjects[0]);
+		// 		}
+
+		// 		if (!contactHitProcessed && hitObjects[0].IsInherited(InventoryItem))
+		// 			contactPosition = hitObjects[0].GetPosition();
+		// 	}
+		// }
+
+		static const float raycastOriginOffsetOnFail = 0.25;
+		static const float minDistFromStart = 0.01;
+		// Camera isn't correctly positioned in some cases, leading to raycasts hitting the object directly behind the camera
+		if ((hitObjects.Count() > 0) && (vector.DistanceSq(from, contactPosition) < minDistFromStart))
+		{
+			from = contactPosition + GetGame().GetCurrentCameraDirection() * raycastOriginOffsetOnFail;
+			DayZPhysics.RaycastRV(from, to, contactPosition, m_ContactDir, m_ContactComponent, hitObjects, player, m_Projection, false, false, ObjIntersectFire);
+		}
+
+		bool isFloating = SetHologramPosition(player.GetPosition(), minProjectionDistance, maxProjectionDistance, contactPosition);
+		SetIsFloating(isFloating);
+
+		#ifdef DIAG_DEVELOPER
+		DrawDebugArrow(minProjectionDistance, maxProjectionDistance);
+		if (DiagMenu.GetBool(DiagMenuIDs.MISC_HOLOGRAM))
+		{
+			Debug.DrawSphere(GetProjectionPosition(), 0.1, 0x99FF0000, ShapeFlags.ONCE|ShapeFlags.TRANSP|ShapeFlags.NOOUTLINE);
+		}
+		#endif
+
+		m_FromAdjusted = from;
+
+		return contactPosition;
+	}
 };

--- a/iat/release_version.hpp
+++ b/iat/release_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 0
 #define MINOR 0
 #define PATCH 1
-#define BUILD 19
+#define BUILD 20


### PR DESCRIPTION
just took vanilla code and remove the part that was forcing items to the ground. The built in gameplay json setting was not working so i did this...